### PR TITLE
fix: re-add check-source-childs hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -111,6 +111,12 @@
     entry: check-script-semicolon
     language: python
     types: [sql]
+-   id: check-source-childs
+    name: Check the source has a specific number (max/min) of childs.
+    description: Ensures the source has a specific number (max/min) of childs.
+    entry: check-source-childs
+    language: python
+    types: [sql]
 -   id: check-source-columns-have-desc
     name: Check for source column descriptions
     description: Ensures that the source has columns with descriptions in the properties file.


### PR DESCRIPTION
This was dropped out of the commit history by accident and needs to be re-added to resolve #38